### PR TITLE
Removing the "and" controllflow statement from load_view

### DIFF
--- a/lib/activerecord-database-views/view_collection.rb
+++ b/lib/activerecord-database-views/view_collection.rb
@@ -30,7 +30,8 @@ module ActiveRecord::DatabaseViews
       name = view.name
 
       begin
-        view.load! and views.delete(view)
+        view.load!
+        views.delete(view)
         puts "#{name}: Loaded"
       rescue ActiveRecord::StatementInvalid => exception
         ActiveRecord::Base.connection.rollback_db_transaction


### PR DESCRIPTION
`Connection.execute` returns nil on successful execution and thus creates an infinite loop by failing `view.load!` and not executing `views.delete(view)`.

Logic is kept intact as the SQL request would exit the scope with an exception if the statement fails and so would not delete the view from the list. This way the dependency resolution code would still work fine.
